### PR TITLE
Fix EnterpriseContractPolicy violations

### DIFF
--- a/.tekton/apicast-gateway-push.yaml
+++ b/.tekton/apicast-gateway-push.yaml
@@ -35,6 +35,8 @@ spec:
     value: rh-apicast/apicast/Containerfile
   - name: path-context
     value: rh-apicast/apicast
+  - name: build-source-image
+    value: "true"
   pipelineSpec:
     description: |
       This pipeline is ideal for building multi-arch container images from a Containerfile while maintaining trust after pipeline customization.

--- a/.tekton/apicast-operator-bundle-push.yaml
+++ b/.tekton/apicast-operator-bundle-push.yaml
@@ -30,6 +30,8 @@ spec:
     value: quay.io/redhat-user-workloads/3scale-prod-tenant/apicast-operator-bundle:{{revision}}
   - name: dockerfile
     value: rh-apicast-operator/Containerfile.apicast-operator-bundle
+  - name: build-source-image
+    value: "true"
   pipelineSpec:
     description: |
       This pipeline is ideal for building container images from a Containerfile while maintaining trust after pipeline customization.

--- a/.tekton/apicast-operator-push.yaml
+++ b/.tekton/apicast-operator-push.yaml
@@ -33,6 +33,8 @@ spec:
     - linux/x86_64
   - name: dockerfile
     value: rh-apicast-operator/Containerfile.apicast-operator
+  - name: build-source-image
+    value: "true"
   pipelineSpec:
     description: |
       This pipeline is ideal for building multi-arch container images from a Containerfile while maintaining trust after pipeline customization.

--- a/.tekton/apisonator-push.yaml
+++ b/.tekton/apisonator-push.yaml
@@ -40,6 +40,8 @@ spec:
       - {"type": "bundler", "path": "rh-apisonator/apisonator/"}
   - name: hermetic
     value: "true"
+  - name: build-source-image
+    value: "true"
   pipelineSpec:
     description: |
       This pipeline is ideal for building multi-arch container images from a Containerfile while maintaining trust after pipeline customization.

--- a/.tekton/porta-push.yaml
+++ b/.tekton/porta-push.yaml
@@ -34,6 +34,8 @@ spec:
     - linux/x86_64
   - name: dockerfile
     value: rh-porta/Containerfile
+  - name: build-source-image
+    value: "true"
   pipelineSpec:
     description: |
       This pipeline is ideal for building multi-arch container images from a Containerfile while maintaining trust after pipeline customization.

--- a/.tekton/searchd-push.yaml
+++ b/.tekton/searchd-push.yaml
@@ -41,6 +41,8 @@ spec:
       - {"type": "rpm", "path": "rh-searchd"}
   - name: hermetic
     value: "true"
+  - name: build-source-image
+    value: "true"
   pipelineSpec:
     description: |
       This pipeline is ideal for building multi-arch container images from a Containerfile while maintaining trust after pipeline customization.

--- a/.tekton/toolbox-push.yaml
+++ b/.tekton/toolbox-push.yaml
@@ -39,6 +39,8 @@ spec:
       - {"type": "bundler", "path": "rh-toolbox/toolbox/"}
   - name: hermetic
     value: "true"
+  - name: build-source-image
+    value: "true"
   pipelineSpec:
     description: |
       This pipeline is ideal for building multi-arch container images from a Containerfile while maintaining trust after pipeline customization.

--- a/.tekton/zync-push.yaml
+++ b/.tekton/zync-push.yaml
@@ -40,6 +40,8 @@ spec:
       - {"type": "bundler", "path": "rh-zync/zync/"}
   - name: hermetic
     value: "true"
+  - name: build-source-image
+    value: "true"
   pipelineSpec:
     description: |
       This pipeline is ideal for building multi-arch container images from a Containerfile while maintaining trust after pipeline customization.

--- a/rh-apicast-operator/Containerfile.apicast-operator
+++ b/rh-apicast-operator/Containerfile.apicast-operator
@@ -44,9 +44,11 @@ FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 
 LABEL summary="APIcast operator container image" \
       description="APIcast Operator provides an easy way to install a 3scale APIcast self-managed solution, providing configurability options at the time of installation." \
-            io.k8s.display-name="APIcast Operator" \
-            io.openshift.expose-services="" \
-            io.openshift.tags="3scale, apicast, api, gateway, openresty, api-gateway" \
+      io.k8s.display-name="APIcast Operator" \
+      io.openshift.expose-services="" \
+      io.openshift.tags="3scale, apicast, api, gateway, openresty, api-gateway" \
+      com.redhat.component="3scale-apicast-operator-container" \
+      name="3scale-amp2/apicast-rhel9-operator" \
       vendor="Red Hat, Inc."
 
 ENV OPERATOR_BINARY_NAME="manager" \

--- a/rh-apicast-operator/Containerfile.apicast-operator-bundle
+++ b/rh-apicast-operator/Containerfile.apicast-operator-bundle
@@ -35,6 +35,8 @@ LABEL summary="APIcast operator container image metadata" \
       io.k8s.display-name="APIcast Operator metadata" \
       io.openshift.expose-services="" \
       io.openshift.tags="3scale, apicast, api, gateway, openresty, api-gateway" \
+      com.redhat.component="3scale-apicast-operator-bundle-container" \
+      name="3scale-amp2/apicast-rhel7-operator-metadata" \
       vendor="Red Hat, Inc."
 
 # Copy files to locations specified by labels.

--- a/rh-apisonator/Containerfile
+++ b/rh-apisonator/Containerfile
@@ -29,7 +29,10 @@ LABEL summary="3scale API Management platform backend." \
       io.k8s.description="3scale is an API Management Platform suitable to manage both internal and external API services. This image contains the platform's backend, which takes care of applying rate limits, authorization, and reporting of HTTP(s) requests." \
       io.k8s.display-name="3scale API manager (backend)" \
       io.openshift.expose-services="3000:backend" \
-      io.openshift.tags="api, backend, 3scale, 3scale-amp"
+      io.openshift.tags="api, backend, 3scale, 3scale-amp"\
+      com.redhat.component="3scale-amp-backend-container" \
+      name="3scale-amp2/backend-rhel8" \
+      vendor="Red Hat, Inc."
 
 ARG RUBY_VERSION="3.3"
 ARG BUILD_DEPS="tar make file findutils git patch gcc automake autoconf libtool redhat-rpm-config openssl-devel ruby-devel"

--- a/rh-porta/Containerfile
+++ b/rh-porta/Containerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8:8.10-1161 AS builder
+FROM registry.access.redhat.com/ubi8:8.10-1161.1735829865 AS builder
 
 ENV YARN_MAJOR_VERSION=1 \
     YARN_MINOR_VERSION=22 \
@@ -6,8 +6,8 @@ ENV YARN_MAJOR_VERSION=1 \
 ENV YARN_VERSION="${YARN_MAJOR_VERSION}.${YARN_MINOR_VERSION}.${YARN_PATCH_VERSION}"
 
 
-ENV RUBY_MAJOR_VERSION=2 \
-    RUBY_MINOR_VERSION=7 \
+ENV RUBY_MAJOR_VERSION=3 \
+    RUBY_MINOR_VERSION=1 \
     RAILS_ENV=production \
     NODE_ENV=production
 ENV RUBY_VERSION="${RUBY_MAJOR_VERSION}.${RUBY_MINOR_VERSION}"
@@ -18,10 +18,11 @@ COPY ./rh-porta/porta /opt/system
 
 WORKDIR /opt/system
 
-RUN cp -pR openshift/system/config/* config/ \
+RUN cp -pR config/examples/*.yml config/ \
+    && cp -pR openshift/system/config/* config/ \
     && echo '{"revision": "${CI_X_VERSION}.${CI_Y_VERSION}-stable", "release": "${CI_X_VERSION}.${CI_Y_VERSION}"}' > .deploy_info
 
-RUN dnf -y module enable ruby:${RUBY_VERSION} nodejs:16 mysql:8.0 \
+RUN dnf -y module enable ruby:${RUBY_VERSION} nodejs:18 mysql:8.0 \
     && dnf install -y --setopt=skip_missing_names_on_install=False,tsflags=nodocs shared-mime-info make automake gcc gcc-c++ redhat-rpm-config postgresql rubygem-irb rubygem-rdoc ruby-devel nodejs libpq-devel mysql-devel gd-devel git 'dnf-command(download)' podman-catatonit libxml2-devel libxslt-devel
 
 # install bundler
@@ -46,7 +47,6 @@ RUN yarn --frozen-lockfile --check-files --no-progress \
     && SECRET_KEY_BASE=rails/32947 bundle exec rake assets:precompile tmp:clear \
     && rm -rf node_modules /usr/local/share/gems/cache /usr/local/share/gems/doc
 
-# Generate licenses report file
 # TODO: check if the SBOM provided by konflux already provides the license info
 #RUN LICENSES_REPORT=/root/licenses/3scale-amp-system-container/licenses.xml \
 #    && bundle exec license_finder action_items --quiet \
@@ -76,10 +76,10 @@ RUN dnf install -y mysql-server mysql-test \
     && grep -q "rt_field = account_id" "$THINKING_SPHINX_CONFIGURATION_FILE" \
     && kill $(</run/mysqld/mysqld.pid)
 
-FROM registry.access.redhat.com/ubi8:8.10-1161 AS prod
+FROM registry.access.redhat.com/ubi8:8.10-1161.1735829865 AS prod
 
-ENV RUBY_MAJOR_VERSION=2 \
-    RUBY_MINOR_VERSION=7 \
+ENV RUBY_MAJOR_VERSION=3 \
+    RUBY_MINOR_VERSION=1 \
     SAFETY_ASSURED=1 \
     TZ=:/etc/localtime \
     RAILS_ENV=production \
@@ -113,12 +113,12 @@ COPY --from=builder /opt/system/ .
 COPY --from=builder /usr/local/share/gems /usr/local/share/
 COPY --from=builder /usr/local/bin/bundle* /usr/local/bin
 # TODO: check if the SBOM provided by konflux already provides the license info
-#COPY --from=builder /root/licenses/3scale-amp-system-container/licenses.xml /root/licenses/3scale-amp-system-container/licenses.xml
+# COPY --from=builder /root/licenses/3scale-amp-system-container/licenses.xml /root/licenses/3scale-amp-system-container/licenses.xml
 # in RHEL 8 podman-catatonit pulls in too many useless deps so we don't install the RPM directly, on RHEL 9 simply use package `catatonit`
 COPY --from=builder /usr/libexec/catatonit/catatonit /usr/libexec/catatonit/catatonit
 
 RUN subscription-manager refresh \
-    && dnf -y --setopt=module_stream_switch=True module enable ruby:${RUBY_VERSION} nodejs:16 mysql:8.0 \
+    && dnf -y --setopt=module_stream_switch=True module enable ruby:${RUBY_VERSION} nodejs:18 mysql:8.0 \
     && dnf install -y --setopt=skip_missing_names_on_install=False,tsflags=nodocs shared-mime-info postgresql rubygem-irb rubygem-rdoc ruby libpq mysql mysql-libs gd git liberation-sans-fonts file libxml2 libxslt jemalloc \
     && dnf -y clean all
 

--- a/rh-porta/Containerfile
+++ b/rh-porta/Containerfile
@@ -101,7 +101,11 @@ LABEL summary="3scale API Management platform main system." \
                    including usage policies, access control, analytics, \
                    developer portal, and API documentation." \
       io.openshift.expose-services="3000:system,9306:system" \
-      io.openshift.tags="integration, api management, 3scale, rhamp, developer portal, api documentation, api analytics"
+      io.openshift.tags="integration, api management, 3scale, rhamp, developer portal, api documentation, api analytics"\
+      com.redhat.component="3scale-amp-system-container" \
+      name="3scale-amp2/system-rhel8" \
+      vendor="Red Hat, Inc."
+
 
 WORKDIR $HOME
 

--- a/rh-toolbox/Containerfile
+++ b/rh-toolbox/Containerfile
@@ -17,7 +17,10 @@ LABEL summary="The 3scale command line interface" \
       io.k8s.description="3scale toolbox is a set of tools to help you manage your 3scale product" \
       io.k8s.display-name="3scale Toolbox" \
       io.openshift.expose-services="" \
-      io.openshift.tags="3scale, cli, toolbox, openapi, rubygems, rhamp"
+      io.openshift.tags="3scale, cli, toolbox, openapi, rubygems, rhamp"\
+      com.redhat.component="3scale-toolbox-container" \
+      name="3scale-amp2/toolbox-rhel8" \
+      vendor="Red Hat, Inc."
 
 ENV TZ=:/etc/localtime \
     DISABLE_SPRING=1

--- a/rh-zync/Containerfile
+++ b/rh-zync/Containerfile
@@ -16,6 +16,8 @@ LABEL summary="Zync - the sync tool" \
                    and push it somewhere else, reliably. \
                    Offers only one directional sync (from 3scale to other systems)." \
       vendor="Red Hat, Inc." \
+      com.redhat.component="3scale-amp-zync-container" \
+      name="3scale-amp2/zync-rhel9" \
       io.k8s.display-name="Zync" \
       io.k8s.description="Zync is going to take your 3scale data \
                    and push it somewhere else, reliably. \


### PR DESCRIPTION
some labels were previously removed because I thought they were only used by the old RH build service, but it turns out the EnterpriseContractPolicy cares about these enough to fail the release. 

also this fixes the list of allowed registries